### PR TITLE
feat(console): add adaptor for the subprocess module

### DIFF
--- a/helpers/console/README.md
+++ b/helpers/console/README.md
@@ -1,0 +1,16 @@
+# Console Applications
+
+Helpers for Python console applications.
+
+
+## Executing Python Projects
+Change permissions of the entry-point file to be executable and add the following
+line to the opening of the file.
+```Python
+#!/usr/bin/env python
+```
+### Module Entry Points
+Typically main.py but any file will do.
+
+### Package Entry Points
+\_\_main\_\_.py

--- a/helpers/console/command.py
+++ b/helpers/console/command.py
@@ -1,0 +1,36 @@
+import argparse
+import os
+import subprocess
+from collections import namedtuple
+from dataclasses import dataclass
+
+
+@dataclass
+class CommandResult:
+    cmd: str
+    output: str
+    error: str
+    exit_code: int
+
+
+class Command:
+    def __init__(self, cmd):
+        self.command = cmd
+
+    @staticmethod
+    def get_result(cmd, captures=True, encodes="UTF-8", **kwargs):
+        return subprocess.run(
+            cmd, shell=True, capture_output=captures, encoding=encodes, **kwargs
+        )
+
+    @staticmethod
+    def wrap_result(cmd_process):
+        return CommandResult(
+            cmd=cmd_process.args,
+            output=cmd_process.stdout,
+            error=cmd_process.stderr,
+            exit_code=cmd_process.returncode,
+        )
+
+    def execute(self):
+        return self.wrap_result(self.get_result(self.command))


### PR DESCRIPTION
Why
===

The subprocess module is the recommend method of interacting with the
shell but used incorrectly can leave applications vulnerable to
command injection attacks.

This change addresses the need by
=================================

* wraps subprocess.run in Command class thereby discouraging use of os.system
* wraps subprocess run results in CommandResult class
* CommandResult class captures stdin and stderr and UTF-8 encodes results
