### PR TITLE
Remove use pytest-runner

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ LICENSES = {
 }
 REQUIREMENTS = {
     'install': [],
-    'setup': ['pytest-runner'],
+    'setup': [''],
     'tests': ['pytest']
 }
 


### PR DESCRIPTION
Acording to my conversation with `pytest-runner` maintainer this module should be no longer used.
Maintainer added about that "Deprecation Notice" on https://github.com/pytest-dev/pytest-runner

<!-- Please replace {YOUR_DESCRIPTION} with requested information. -->

### What was a problem?
`pytest-runner` is no longer maintained and should be no longer used.

### How this PR fixes the problem?
It removes use `pytest-runner` from setup.cfg.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [ ] Linted with...
- [ ] Formatted with...

### Additional Comments?
N/A
